### PR TITLE
fix: replaying endpoints with query-params

### DIFF
--- a/src/recordedHarMiddleware.ts
+++ b/src/recordedHarMiddleware.ts
@@ -1,4 +1,4 @@
-import type { Request, Response, NextFunction } from 'express';
+import type { NextFunction, Request, Response } from 'express';
 import type { LoadHarDataFn } from './harUtils';
 import { findHarEntry } from './harUtils';
 
@@ -13,7 +13,7 @@ export const recordedHarMiddleware = (harFilePath: string, getHar: LoadHarDataFn
   return async (req: Request, res: Response, next: NextFunction) => {
     try {
       const har = await getHar(harFilePath);
-      const baseUrl = req.baseUrl.slice(prefix.length); // remove prefix
+      const baseUrl = req.originalUrl.slice(prefix.length); // remove prefix
       const method = req.method;
 
       const recordedEntry = findHarEntry(har.log, method, baseUrl);


### PR DESCRIPTION
This fixes replaying requests for endpoints with query params, although there is still an issue that only the first matching request will be replayed.

Assuming we have a POST endpoint that we sent a payload to, and assuming we have made multiple requests to this endpoint with different payloads then only the first request will be replayed.

It might make sense to extend the matching logic to also check the request body if it is a POST request.