### PR TITLE
play: fix base64 responses

### DIFF
--- a/src/recordedHarMiddleware.ts
+++ b/src/recordedHarMiddleware.ts
@@ -21,7 +21,24 @@ export const recordedHarMiddleware = (harFilePath: string, getHar: LoadHarDataFn
       if (recordedEntry) {
         const { status, content } = recordedEntry.response;
         res.status(status).set('Content-Type', content.mimeType);
-        res.send(content.text);
+        if (content.text == undefined) {
+          console.error(`HAR entry has no body`);
+          return next();
+        }
+        switch (content.encoding) {
+          case undefined: {
+            res.send(content.text);
+            break;
+          }
+          case 'base64': {
+            res.send(Buffer.from(content.text, 'base64'));
+            break;
+          }
+          default: {
+            console.error(`Unknown .content.encoding in HAR entry: ${content.encoding}`);
+            return next();
+          }
+        }
       } else {
         return next();
       }


### PR DESCRIPTION
Chrome devtools generates HAR files with some response bodies in base64, which harproxyserver currently serves to the client verbatim. This patch fixes that by checking the .content.encoding and decoding if necessary.

Example: [book.servo.org.har.zip](https://github.com/user-attachments/files/17108219/book.servo.org.har.zip)