### PR TITLE
Update to Rollup and TypeScript config to allow the types to be exported properly. 

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
         "dist"
     ],
     "exports": {
-        ".": "./dist/index.min.js",
+        ".": "./dist/index.js",
         "./harProxyServer": "./dist/harProxyServer.js"
     },
     "scripts": {

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -15,7 +15,7 @@ export default [
       {
         dir: 'dist',
         format: 'cjs',
-        entryFileNames: '[name].min.js',
+        entryFileNames: '[name].js',
         sourcemap: true,
         plugins: [terser()],
       },

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 export * from './harUtils';
 export * from './recordedHarMiddleware';
 export * from './recorderHarMiddleware';
+export * from "./harFileUtils";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,7 +26,7 @@
 
     /* Modules */
     "module": "commonjs",                                /* Specify what module code is generated. */
-    "rootDir": "./",                                  /* Specify the root folder within your source files. */
+    "rootDir": "./src",                                  /* Specify the root folder within your source files. */
     // "moduleResolution": "node16",                     /* Specify how TypeScript looks up a file from a given module specifier. */
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
     // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */


### PR DESCRIPTION
See my inline comments for more details. 

I'm not entirely comfortable with this PR because I think there's something funky going on with the rollup config. It seems that roll up is generating output code twice or something - once with a pure typescript output, and then a second one that creates the minified index.js. That second one wasn't outputting types, but I've renamed it index.js so it lines up with the generated index.d.ts 

I can't see that rollup is necessary here. I think you could tidy this up by just removing it, and using TypeScript as the compiler. 

